### PR TITLE
Allow installing against node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Observe when something in your node app starts listening on a TCP port",
   "main": "index.js",
   "engines": {
-    "node": "^9.4.0 || ^8.9.4"
+    "node": "^10.0.0 || ^9.4.0 || ^8.9.4"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Yarn actually pays attention to the node engines specifier and throws an error when trying to install this or a dependent against node 10. I opened a similar PR for [node-clinic](https://github.com/nearform/node-clinic/pull/35).