### PR TITLE
fix: unix domain socket

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ function onListening (onlistening) {
     init (asyncId, type, triggerAsyncId, resource) {
       if (type === 'PIPESERVERWRAP' || type === 'TCPSERVERWRAP') {
         process.nextTick(function () {
+          if (Object.prototype.toString.call(resource) !== '[Object TCP]') {
+            return;
+          }
           resource.owner.once('listening', function () {
             var addr = resource.owner.address()
             if (addr) e.emit('listening', addr)


### PR DESCRIPTION
Listening to unix domain socket will cause error now

```js
const Koa = require('koa');
const app = new Koa();
const onnetlisten = require('on-net-listen');

app.use(ctx => {
  ctx.status = 200;
  ctx.body = {}; 
});

onnetlisten(addr => {
  console.log(addr);
});

app.listen('./app.sock');
```

```
/node_modules/on-net-listen/index.js:17
          resource.owner.once('listening', function () {
                         ^

TypeError: Cannot read property 'once' of undefined
    at /Users/xuxingyu/code/ci/node_modules/on-net-listen/index.js:17:26
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```

Because the `resource` is not an instance of TCP